### PR TITLE
fix bug to add category image for admin dashboard

### DIFF
--- a/shopyo/modules/resource/models.py
+++ b/shopyo/modules/resource/models.py
@@ -43,11 +43,11 @@ class Resource(db.Model):
 
     # 
     product_id = db.Column(db.Integer, db.ForeignKey('product.id'),
-        nullable=False)
+        nullable=True)
     category_id = db.Column(db.Integer, db.ForeignKey('categories.id'),
         nullable=False)
     subcategory_id = db.Column(db.Integer, db.ForeignKey('subcategories.id'),
-        nullable=False)
+        nullable=True)
 
     def insert(self):
         db.session.add(self)


### PR DESCRIPTION
# Add category image to replace placeholder category image of admin dashboard

Add category image to admin dashboard. Does not yet apply the new category image to the category image on the home page. 

Bug is described here: [https://github.com/shopyo/ShopCube/issues/3](https://github.com/shopyo/ShopCube/issues/3)

## Description

Modified the nullable=False to nullable=true for product_id and subcategory_id for the Resource model. 

## Screenshots (if appropriate):

### Before
![Screen Shot 2021-10-21 at 11 03 57 PM](https://user-images.githubusercontent.com/13709437/138401315-5c585bfd-670b-4b76-a3dc-a7c8e9731eb9.png)

### After
![Screen Shot 2021-10-21 at 10 30 24 PM](https://user-images.githubusercontent.com/13709437/138398267-cac9f7d1-ae12-492e-b11a-330372f0b21b.png)

Brought this additional bug to the attention of maintainers: Need the added category image to display on the home page 

![Screen Shot 2021-10-21 at 10 30 50 PM](https://user-images.githubusercontent.com/13709437/138398299-a0f9044a-b69c-4dc2-bef5-9b26e5e6ca8a.png)

## Types of changes
`<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->`

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (improves application but is not new functionality nor a bug fix)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. -- N/A
